### PR TITLE
Fix Tiled map rendering, and one memory leak, and Tiled map position querying

### DIFF
--- a/client/code/gameactors.pas
+++ b/client/code/gameactors.pas
@@ -63,8 +63,8 @@ begin
 	// TODO: use vId to get info about the appearance of the actor from some other component
 	// (which will manage network in return, to get this data)
 	result.URL := 'castle-data:/images/player.png';
-	result.Scale := Vector3(0.0025, 0.0025, 0.0025); // TODO: scale properly
-	result.Translation := Vector3(0, 0, 0.05); // TODO: proper Z distance
+	result.Scale := Vector3(0.0025, 0.0025, 1); // TODO: scale properly
+	result.Translation := Vector3(0, 0, 100); // TODO: proper Z distance
 
 	// TODO: set up some properties of the actor, like position, health etc. Or
 	// maybe use more automated means of updating them according to network

--- a/client/code/gamestate.pas
+++ b/client/code/gamestate.pas
@@ -82,7 +82,7 @@ begin
 
 	vProportionX := FMapData.Map.SizeX / FUIBoard.Map.Width / FUIBoard.Map.TileWidth;
 	vProportionY := FMapData.Map.SizeY / FUIBoard.Map.Height / FUIBoard.Map.TileHeight;
-	FUIBoard.Scale := Vector3(vProportionX, vProportionY, 0);
+	FUIBoard.Scale := Vector3(vProportionX, vProportionY, 1);
 	// FUIBoard.Translation := Vector3(FMapData.Map.SizeX / 2, FMapData.Map.SizeY / 2, 0);
 end;
 

--- a/client/code/models/gamemodels.pas
+++ b/client/code/models/gamemodels.pas
@@ -93,7 +93,9 @@ function TJSONModelSerialization.DeSerialize(const vSerialized: String; const vM
 			vNewObject.Add(cArrayWrapKey, vJsonMaybeArray);
 
 			result := vNewObject.AsJson;
-		end;
+			FreeAndNil(vNewObject);
+		end else
+		    FreeAndNil(vJsonMaybeArray);
 	end;
 
 begin


### PR DESCRIPTION
This fixes:

1. Tiled map rendering, adjusting scale of the map (to have scale in Z <> 0). Following this, also actors need to be placed at large Z (I used 100) to be above map. Details in https://github.com/castle-engine/castle-engine/issues/567 

2. Memory leak in TJSONModelSerialization.DeSerialize I noticed and also mentioned in https://github.com/castle-engine/castle-engine/issues/567 

3. Map position query, using `MouseRayHit` before the PR. The details why the fix is necessary are in https://github.com/castle-engine/castle-engine/issues/570 (please give me a few minutes after receiving this PR, I'm in the middle of finishing my full comment to this post :) ).

Be sure to use the latest CGE -- I have just pushed to CGE a new method `TRayCollision.Info` that this PR is relying upon. If you use CGE downloads from https://castle-engine.io/download , please give Jenkins a few hours to make a new release.  When the page https://github.com/castle-engine/castle-engine/compare/snapshot...master will *no longer show the commit titled "Add TRayCollision.Info to easily get TRayCollisionNode that you want ..."* then it means this commit is part of the release downloadable on https://castle-engine.io/download .